### PR TITLE
use OCI_THREADED when creating EnvHandle

### DIFF
--- a/Database/Oracle/OCIConstants.hs
+++ b/Database/Oracle/OCIConstants.hs
@@ -23,6 +23,8 @@ import Foreign.C.Types
 oci_DEFAULT :: CInt
 oci_DEFAULT = 0
 
+oci_THREADED :: CInt
+oci_THREADED = 1
 
 -- ** Handle types:
 

--- a/Database/Oracle/OCIFunctions.hs
+++ b/Database/Oracle/OCIFunctions.hs
@@ -313,7 +313,7 @@ testForErrorWithPtr rc msg retval = do
 
 envCreate :: IO EnvHandle
 envCreate = alloca $ \ptr -> do
-  rc <- ociEnvCreate ptr oci_DEFAULT nullPtr nullFunPtr nullFunPtr nullFunPtr 0 nullPtr
+  rc <- ociEnvCreate ptr oci_THREADED nullPtr nullFunPtr nullFunPtr nullFunPtr 0 nullPtr
   testForErrorWithPtr rc "allocate initial end" ptr
 
 handleAlloc :: CInt -> OCIHandle -> IO OCIHandle

--- a/takusen-oracle.cabal
+++ b/takusen-oracle.cabal
@@ -1,5 +1,5 @@
 Name:           takusen-oracle
-Version:        0.9.3
+Version:        0.9.3.2
 License:        BSD3
 License-file:   LICENSE
 Author:         Alistair Bayley, Oleg Kiselyov, Pavel Ryzhov


### PR DESCRIPTION
This addresses #3 by using the proper constant to enable safe multithreading. Credit due to @cartazio for digging through the OCI docs to find the culprit.