### PR TITLE
Remove call to OCITerminate() when disconnecting from database. Fixes #12

### DIFF
--- a/Database/Oracle/Enumerator.hs
+++ b/Database/Oracle/Enumerator.hs
@@ -298,7 +298,6 @@ dbDisconnect session = do
   logoff err conn
   dispose err
   dispose env
-  OCI.terminate
 
 
 -- |Oracle only supports ReadCommitted and Serialisable.


### PR DESCRIPTION
Please see issue #12.